### PR TITLE
Change repo-specific references to generic

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team via the [repository maintainers](mailto:repo-maintainers@mailing-list-placeholder.com). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team via the [repository maintainers](https://github.com/eiffel-community/community/blob/master/CONTACT.md). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Thank you for contributing to the Eiffel Community!
 The following is a set of guidelines for contributing to this repository.
 
 ## How to Propose Changes
-Anyone is welcome to propose changes to the contents of this repository by creating a new [Issue](https://github.com/eiffel-community/eiffel-repository-template/issues) ticket in GitHub. These requests may concern anything contained in the repo: changes to documentation, bug fixes, requests for additional information, additional event types, requests for additional examples, new featuers et cetera.
+Anyone is welcome to propose changes to the contents of this repository by creating a new Issue ticket in GitHub. These requests may concern anything contained in the repo: changes to documentation, bug fixes, requests for additional information, additional event types, requests for additional examples, new featuers et cetera.
 
 When posting a new issue, try to be as precise as possible and phrase your arguments for your request carefully. Keep in mind that collaborating on software development is often an exercise in finding workable compromises between multiple and often conflicting needs; this is particularly true for defining a shared protocol such as Eiffel. In particular, pay attention to the following:
 1. What type of change is requested?
@@ -33,7 +33,7 @@ When posting a new issue, try to be as precise as possible and phrase your argum
 Also, keep in mind that just as anyone is welcome to propose a change, anyone is welcome to disagree with and criticize that proposal.
 
 ### Closing Issues
-An Issue can be closed by any member of [the repository maintainers' team](https://github.com/orgs/eiffel-community/teams/eiffel-repository-template-maintainers). This can happen in various ways, for varying reasons:
+An Issue can be closed by any member of [the repository maintainers' team](https://github.com/eiffel-community/community/blob/master/CONTACT.md). This can happen in various ways, for varying reasons:
 1. Issues without conclusion and no activity for at least 14 days may be closed, as a mere housekeeping activity. For instance, an Issue met with requests for further clarification, but left unanswered by the original author, may simply be removed.
 1. Issues may simply be rejected if found unfeasible or undesirable. In such cases they shall also be responded to, providing a polite and concise explanation as to why the proposal is rejected.
 1. Issues may be closed because they are implemented. Following the successful merging of a pull request addressing an Issue, it will be closed.
@@ -49,7 +49,7 @@ Contributions can be made by anyone using the standard [GitHub Fork and Pull mod
 ### Reviewing and Merging Pull Requests
 We use the Squash and Merge model, which means that all commits in a Pull Request get squashed into a single commit in the target branch. In other words, the revision history will look like a string of single commits corresponding one-to-one with Issues.
 
-Pull requests can be merged by members of the [the repository maintainers' team](https://github.com/orgs/eiffel-community/teams/eiffel-repository-template-maintainers). There is a certain protocol to adhere to, however, as well as expectations on membership.
+Pull requests can be merged by members of the [the repository maintainers' team](https://github.com/eiffel-community/community/blob/master/CONTACT.md). There is a certain protocol to adhere to, however, as well as expectations on membership.
 1. All maintainers are expected to make the effort to participate in the review of Pull Requests. Every maintainer may not review everything in detail, but everyone can make the effort to chime in on some. Remember that expedient high quality reviews are crucial to the long term survival of any open source project.
 1. All community members, maintainers or not, are strongly encouraged to participate in reviews even if they do not feel entirely qualified to assess the pull request. Looking at changes and participating in review discussions is one of the best ways to learn, and presents an excellent opportunity to ask questions. And remember, participating in a review is not the same as having to make the final decision.
 1. A Pull Request should be approved by at least two maintainers (including the one doing the merging). For this to function well, the above point on participation is critical.


### PR DESCRIPTION
### Applicable Issues
https://github.com/eiffel-community/community/issues/13

### Description of the Change
Change repository-specific references and links to generic references and links, so that any repository can use these files.

See also: https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization

This PR is only one part of the solution -- the following items must also be solved before we can close the issue above.

* There is need to delete CODE_OF_CONDUCT.md and CONTRIBUTING.md in all eiffel repositories so that the default files can be federated (otherwise the files in the repository will take precedence and no changes to the default files will be seen)
* We need to update the eiffel-repository-template so that not README.md and  repo-checklist.md so that links are referencing the CODE_OF_CONDUCT.md and CONTRIBUTING.md in .github repo instead of each separate repo.

### Alternate Designs
No alternate design was considered.

### Benefits
We would not have the need to update multiple different files if we have a central default setup. The repository will not be cluttered with these file (even though they are important files).

### Possible Drawbacks
The possible drawback is that it will be slightly less obvious where to find the files, but each README.md should contain links to the default files, so hopefully this will not be a problem

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Henning Roos henning.roos@gmail.com