### PR TITLE
Add SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 We as a community encourage researchers, users and contributors to report vulnerabilities and security related issues to the Eiffel community. All issues are thoroughly investigated by a community security officer and/or other community security volunteers. All reported and fixed security and vulnerability issues can be found on the [Eiffel community security page](https://eiffel-community.github.io/security.html) .
 
 ## How to Report a Security Vulnerability
-To file a vulnerability report please send and e-mail to the private eiffel-community-security@googlegroups.com  list. The e-mail should list the security specific details as well as the [standard bug report information](https://github.com/eiffel-community/.github/blob/master/.github/ISSUE_TEMPLATE.md). Only the community security officers will have access to e-mails sent on the security and vulnerability list. This process is the same whether the report stems from a project within the Eiffel community or from an external contributor. 
+To file a vulnerability report please send and e-mail to the private eiffel-community-security@googlegroups.com  list. The e-mail should list the security specific details as well as the [standard bug report information](https://github.com/eiffel-community/.github/blob/master/.github/ISSUE_TEMPLATE/general.md). Only the community security officers will have access to e-mails sent on the security and vulnerability list. This process is the same whether the report stems from a project within the Eiffel community or from an external contributor. 
 
 Triage and handling of the vulnerability report will be conducted within one week. If the vulnerability severity and impact is high a patch will be published with urgency.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Eiffel-community Vulnerability and Security Reporting and Response
+
+## Report a Vulnerability or Security Issue
+We as a community encourage researchers, users and contributors to report vulnerabilities and security related issues to the Eiffel community. All issues are thoroughly investigated by a community security officer and/or other community security volunteers. All reported and fixed security and vulnerability issues can be found on the [Eiffel community security page](https://eiffel-community.github.io/security.html) .
+
+## How to Report a Security Vulnerability
+To file a vulnerability report please send and e-mail to the private eiffel-community-security@googlegroups.com  list. The e-mail should list the security specific details as well as the [standard bug report information](https://github.com/eiffel-community/.github/blob/master/.github/ISSUE_TEMPLATE.md). Only the community security officers will have access to e-mails sent on the security and vulnerability list. This process is the same whether the report stems from a project within the Eiffel community or from an external contributor. 
+
+Triage and handling of the vulnerability report will be conducted within one week. If the vulnerability severity and impact is high a patch will be published with urgency.
+
+## When Should I Report a Vulnerability?
+* You think you discovered a potential security vulnerability in an eiffel-community service, application or repository
+* You are unsure how a vulnerability affects the eiffel-community service or application.
+* You think you discovered a vulnerability in another project that a eiffel-community service or application depends on.
+
+## Security Vulnerability Response
+As mentioned, each report is acknowledged and analyzed by a eiffel-community security officer within one week. If the vulnerability is reproduced and verified a response will be sent to the reporter. As the issue progresses from triage, to fix, test and release the reporter will be updated.
+
+## Public Disclosure
+The eiffel-community humbly asks all vulnerability reporters to hold off on public disclosure and instead negotiate a time frame within which the vulnerability report will be processed, fixed and released by the eiffel-community. Once released it will be listed on the [Eiffel community security page](https://eiffel-community.github.io/security.html) .


### PR DESCRIPTION
### Applicable Issues
N/A; change done as a result of discussion at the [2022-02-10 TC meeting](https://hackmd.io/sL9z7MGwSCOGSCXeY27mFg?view#February-10-2022).

### Description of the Change
Move the SECURITY.md file from the Community repository to this repository so that one can get information about security notices in all repositories.

### Alternate Designs
We currently have this file in the community repository which is an alternate design. The TC, however, wants this notice to be in all repositories.

### Benefits
Easier to see the security policy of Eiffel community

### Possible Drawbacks
None that I can think of.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>