### PR TITLE
Replace links to CONTACT.md with PROJECTS.md links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team via the [repository maintainers](https://github.com/eiffel-community/community/blob/master/CONTACT.md). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team via the [repository maintainers](https://github.com/eiffel-community/community/blob/master/PROJECTS.md). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ When posting a new issue, try to be as precise as possible and phrase your argum
 Also, keep in mind that just as anyone is welcome to propose a change, anyone is welcome to disagree with and criticize that proposal.
 
 ### Closing Issues
-An Issue can be closed by any member of [the repository maintainers' team](https://github.com/eiffel-community/community/blob/master/CONTACT.md). This can happen in various ways, for varying reasons:
+An Issue can be closed by any member of [the repository maintainers' team](https://github.com/eiffel-community/community/blob/master/PROJECTS.md). This can happen in various ways, for varying reasons:
 1. Issues without conclusion and no activity for at least 14 days may be closed, as a mere housekeeping activity. For instance, an Issue met with requests for further clarification, but left unanswered by the original author, may simply be removed.
 1. Issues may simply be rejected if found unfeasible or undesirable. In such cases they shall also be responded to, providing a polite and concise explanation as to why the proposal is rejected.
 1. Issues may be closed because they are implemented. Following the successful merging of a pull request addressing an Issue, it will be closed.
@@ -34,7 +34,7 @@ We use the Squash and Merge model, which means that all commits in a Pull Reques
 
 To facilitate reviews, address feedback by pushing additional commits to the pull request branch rather than using forced pushes to replace the original commit(s). Because the branch will get squashed there is no point in keeping the string of commits on the pull request branch tidy; it's only the squashed result that matters.
 
-Pull requests can be merged by members of the [the repository maintainers' team](https://github.com/eiffel-community/community/blob/master/CONTACT.md). There is a certain protocol to adhere to, however, as well as expectations on membership.
+Pull requests can be merged by members of the [the repository maintainers' team](https://github.com/eiffel-community/community/blob/master/PROJECTS.md). There is a certain protocol to adhere to, however, as well as expectations on membership.
 1. All maintainers are expected to make the effort to participate in the review of Pull Requests. Every maintainer may not review everything in detail, but everyone can make the effort to chime in on some. Remember that expedient high quality reviews are crucial to the long term survival of any open source project.
 1. All community members, maintainers or not, are strongly encouraged to participate in reviews even if they do not feel entirely qualified to assess the pull request. Looking at changes and participating in review discussions is one of the best ways to learn, and presents an excellent opportunity to ask questions. And remember, participating in a review is not the same as having to make the final decision.
 1. For a sandbox project we recommend at least two maintainers (including the one doing the merging) to approve the Pull Request. For this to function well, the maintainers need to participate as stated in the previous point.
@@ -43,7 +43,7 @@ Pull requests can be merged by members of the [the repository maintainers' team]
 1. When squashing and merging, ensure that the description reflects the change. Detailing every individual commit in the Pull Request is unnecessary, as they are squashed anyway. Instead, describe the change as a single thing. That description should always include an Issue reference, and should focus on WHY the change was made, to provide the reader with context. See [this excellent guide](https://chris.beams.io/posts/git-commit) on writing good commit messages.
 
 ### Closing pull requests
-If the author of an pull request has not made any changes or status updates in one months time, any member of [the repository maintainers' team](https://github.com/eiffel-community/community/blob/master/CONTACT.md) should notify the author that they will close the pull request(see below for an example). The member should wait a week after putting the notice before closing the pull request.
+If the author of an pull request has not made any changes or status updates in one months time, any member of [the repository maintainers' team](https://github.com/eiffel-community/community/blob/master/PROJECTS.md) should notify the author that they will close the pull request(see below for an example). The member should wait a week after putting the notice before closing the pull request.
 
   > No one has made an update to this pull request for one month. Please add a status update or we will close this pull request.
 


### PR DESCRIPTION
### Applicable Issues
https://github.com/eiffel-community/community/issues/106

### Description of the Change
The contents of the community repo's CONTACT.md and PROJECTS.md were so similar that they were merged into a single file, PROJECTS.md. Adjusted all links accordingly.

### Alternate Designs
None.

### Benefits
No 404s when CONTACT.md is removed :-)

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
