### PR TITLE
Remove unnecessary backslashes from feature request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,8 +9,8 @@ body:
     attributes:
       label: Summary
       value: |
-        **As** "role name"\
-        **I want** "a feature or functionality"\
+        **As** "role name"
+        **I want** "a feature or functionality"
         **So that** "I get certain business value"
     validations:
       required: true


### PR DESCRIPTION
### Applicable Issues
N/A; this is a trivial YAML formatting issue

### Description of the Change
The feature request issue template's summary field uses backslashes at the end of some of the lines, but since the value's block style is literal there's no need for any escaping. These backslashes instead show up in the pre-filled issue form.

### Alternate Designs
None.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
